### PR TITLE
Added to README and upped `react-scripts`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,30 @@
 A Google Maps inspired frontend for the [CycleStreets](https://www.cyclestreets.net/) cycle journey planner API, built with TypeScript, React, Redux and Mapbox GL JS (via react-map-gl).
 
 [Demo](https://cyclestreets-frontend.alexnorton.com/)
+
+## How to run this locally
+
+### Get a CycleStreets API key
+
+In order to run this app you'll need a [CycleStreets API key](https://www.cyclestreets.net/api/apply/).
+
+### NodeJS
+
+This repo is built using Create React App and you'll need NodeJS installed on your machine to build and run it. The minimum supported version of Node is indicated in [the Create React App docs](https://create-react-app.dev/docs/getting-started/).
+
+### Install, build and run
+
+These are the commands to get started
+
+```
+# install
+npm install
+
+# build
+npm run-script build
+
+# run
+npm run-script start
+```
+
+

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^16.9.0",
     "react-map-gl": "^5.0.11",
     "react-redux": "^7.1.1",
-    "react-scripts": "3.1.1",
+    "react-scripts": "3.1.2",
     "redux": "^4.0.4",
     "redux-thunk": "^2.3.0",
     "styled-components": "^4.4.0",


### PR DESCRIPTION
I had a go at getting this running locally and documented the things I needed to do in the README and by upping `react-scripts`. 

Not sure if upping the dependency is the right way to fix the error. Feels like there's probably some other reason for getting that definition error with version `3.1.1`?